### PR TITLE
lock all python packages versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,14 @@
 # Please see the Get Started section of the ESP-IDF Programming Guide for further information.
 #
 setuptools==50.3.2
+wheel==0.37.1
 # The setuptools package is required to install source distributions and on some systems is not installed by default.
 # Please keep it as the first item of this list.
 #
-pyserial>=3.0
-future>=0.15.2
-cryptography>=2.1.4
-pyparsing>=2.0.3,<2.4.0
+cffi==1.15.1
+cryptography==3.2.1
+future==0.18.2
+pycparser==2.21
+pyparsing==2.3.1
+pyserial==3.5
+six==1.16.0


### PR DESCRIPTION
virtualenv installs at run wheel version 0.38.0 
this version is not compatible with python 3.5
all other python packages versions have been locked to prevent future similar failure